### PR TITLE
Divide ticks_per_second by refresh_rate

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -4,7 +4,7 @@ local nixie_map = {}
 local mod_version="0.1.7"
 local mod_data_version="0.1.0"
 
-local ticksPerRefresh = math.ceil(60*refresh_rate)
+local ticksPerRefresh = math.ceil(60 / refresh_rate)
 
 ---[[
 local function print(...)


### PR DESCRIPTION
Multiplying kind of goes the wrong way here, particularly given `config.lua` says it should be otherwise.